### PR TITLE
Bump official GitHub actions

### DIFF
--- a/cache-crate/action.yml
+++ b/cache-crate/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache crate dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/

--- a/cache-crates/action.yml
+++ b/cache-crates/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache all crates dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/

--- a/cache-idl-generators/action.yml
+++ b/cache-idl-generators/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache IDL generators
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ./.crates/
         key: ${{ runner.os }}-${{ inputs.key }}-${{ hashFiles('**/Cargo.lock') }}

--- a/cache-program/action.yml
+++ b/cache-program/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache program dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/

--- a/cache-programs/action.yml
+++ b/cache-programs/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache all program dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/

--- a/filter-matrix/README.md
+++ b/filter-matrix/README.md
@@ -33,7 +33,7 @@ jobs:
       program_matrix: ${{ steps.filter.outputs.matrix }}
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Detect changes
         uses: dorny/paths-filter@v2

--- a/install-anchor-cli/action.yml
+++ b/install-anchor-cli/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Cache Anchor CLI
       id: cache
       if: inputs.cache == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/anchor

--- a/install-cargo-release/action.yml
+++ b/install-cargo-release/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Cache cargo-release
       id: cache
       if: inputs.cache == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/cargo-release

--- a/install-node-dependencies/action.yml
+++ b/install-node-dependencies/action.yml
@@ -23,7 +23,7 @@ runs:
   steps:
     - name: Cache dependencies
       if: inputs.cache == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ inputs.folder }}/js/node_modules/
         key: ${{ runner.os }}-${{ inputs.key }}-${{ hashFiles(format('{0}/pnpm-lock.yaml, {0}/package-lock.json, {0}/yarn.lock', inputs.folder)) }}

--- a/install-node-with-pnpm/action.yml
+++ b/install-node-with-pnpm/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: pnpm/action-setup@v2
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.version }}
         cache: "pnpm"

--- a/install-solana/action.yml
+++ b/install-solana/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Cache Solana
       id: cache
       if: inputs.cache == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.local/share/solana/install/releases/${{ inputs.version }}

--- a/start-validator/action.yml
+++ b/start-validator/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
     - name: Download program builds
       if: inputs.artifacts != 'false'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifacts }}
 


### PR DESCRIPTION
This PR uses the latest version of official GitHub actions so we don't get annoying warnings on the workflow page (see image below).

The end-user API is exactly the same so that introduces no breaking changes. It just means we're using the latest version of Nodes for actions which removes all warnings.

After merging this, we would need to create a new patch tag and force push the `v1` tag to the latest commit ([as recommended by GitHub](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-release-management-for-actions)).

![CleanShot 2024-05-28 at 11 28 59@2x](https://github.com/metaplex-foundation/actions/assets/3642397/9bb09054-1855-4732-901f-329a01bb5901)