### PR TITLE
Allow base URL to be provided when installing Solana

### DIFF
--- a/install-solana/README.md
+++ b/install-solana/README.md
@@ -12,3 +12,4 @@ Install Solana with optional caching and verify the installed version.
 - Inputs:
   - `version`: The Solana version to install. Defaults to `stable`.
   - `cache`: Whether the downloaded Solana release should be cached. Defaults to `true`.
+  - `base-url`: The base URL to download the Solana release from. Defaults to `https://release.solana.com` for Solana versions below 1.18.19 and `https://release.anza.xyz` for versions 1.18.19 and above.

--- a/install-solana/action.yml
+++ b/install-solana/action.yml
@@ -9,6 +9,9 @@ inputs:
     description: Whether the downloaded Solana release should be cached
     required: true
     default: "true"
+  base_url:
+    description: The base URL to download the Solana release from — e.g. https://release.solana.com.
+    required: false
 
 runs:
   using: "composite"
@@ -23,10 +26,26 @@ runs:
           ~/.cache/solana
         key: ${{ runner.os }}-solana-v${{ inputs.version }}
 
+    - name: Resolve Base URL
+      id: base_url
+      run: |
+        if [ "${{ inputs.base_url }}" != "" ]; then
+          echo "base_url='${{ inputs.base_url }}'" >> $GITHUB_OUTPUT
+        else
+          cutoff="1.18.19"
+          desired="${{ inputs.version }}"
+          if [ "$(printf '%s\n' "$cutoff" "$desired" | sort -V | head -n1)" = "$desired" ] && [ "$cutoff" != "$desired" ]; then
+            echo "base_url='https://release.solana.com'" >> $GITHUB_OUTPUT
+          else
+            echo "base_url='https://release.anza.xyz'" >> $GITHUB_OUTPUT
+          fi
+        fi
+      shell: bash
+
     - name: Install Solana
       if: inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true'
       run: |
-        sh -c "$(curl -sSfL https://release.solana.com/v${{ inputs.version }}/install)"
+        sh -c "$(curl -sSfL ${{ steps.base_url.output.base_url }}/v${{ inputs.version }}/install)"
       shell: bash
 
     - name: Set Active Solana Version

--- a/install-solana/action.yml
+++ b/install-solana/action.yml
@@ -45,7 +45,7 @@ runs:
     - name: Install Solana
       if: inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true'
       run: |
-        sh -c "$(curl -sSfL ${{ steps.base_url.output.base_url }}/v${{ inputs.version }}/install)"
+        sh -c "$(curl -sSfL ${{ steps.base_url.outputs.base_url }}/v${{ inputs.version }}/install)"
       shell: bash
 
     - name: Set Active Solana Version


### PR DESCRIPTION
This PR builds upon https://github.com/metaplex-foundation/actions/pull/7 from @Yiwen-Gao in order to parameterise the `base-url` input and offer a default value that either uses `solana.com` or `anza.xyz` based on the desired version.

I still need to test this action with some dummy repo to make sure it's all working as expected before marking it as ready.

EDIT: Gave this a test by using different versions and explicit `base_url`s and we're good to go.

P.S.: Please ensure the "Co-Author" part of the commit is not removed when squashing this PR to give @Yiwen-Gao credit.