### PR TITLE
Fix install-solana action

### DIFF
--- a/install-solana/action.yml
+++ b/install-solana/action.yml
@@ -45,11 +45,19 @@ runs:
     - name: Install Solana
       if: inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true'
       run: |
-        if [ "${{ inputs.version }}" = "stable" ]; then
-          sh -c "$(curl -sSfL ${{ steps.base_url.outputs.base_url }}/stable/install)"
-        else
-          sh -c "$(curl -sSfL ${{ steps.base_url.outputs.base_url }}/v${{ inputs.version }}/install)"
-        fi
+        version="${{ inputs.version }}"
+        install_url="${{ steps.base_url.outputs.base_url }}"
+        
+        case "$version" in
+          stable|edge|beta)
+            install_url="$install_url/$version/install"
+            ;;
+          *)
+            install_url="$install_url/v$version/install"
+            ;;
+        esac
+        
+        sh -c "$(curl -sSfL $install_url)"
       shell: bash
 
     - name: Set Active Solana Version

--- a/install-solana/action.yml
+++ b/install-solana/action.yml
@@ -45,7 +45,11 @@ runs:
     - name: Install Solana
       if: inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true'
       run: |
-        sh -c "$(curl -sSfL ${{ steps.base_url.outputs.base_url }}/v${{ inputs.version }}/install)"
+        if [ "${{ inputs.version }}" = "stable" ]; then
+          sh -c "$(curl -sSfL ${{ steps.base_url.outputs.base_url }}/stable/install)"
+        else
+          sh -c "$(curl -sSfL ${{ steps.base_url.outputs.base_url }}/v${{ inputs.version }}/install)"
+        fi
       shell: bash
 
     - name: Set Active Solana Version


### PR DESCRIPTION
Fix wrong URL when installing "stable" version.

The URL would be constructed by appending the version to the URL as "`<base_url>`/v`<version>`/install", which would not work for `stable`.

For instance, URL would be `https://release.anza.xyz/vstable/install`, when it should be `https://release.anza.xyz/stable/install`.

This PR handles this exception.