### PR TITLE
Add code-review action for Solana PR security review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository purpose
+
+Collection of reusable **composite GitHub Actions** for Solana development at Metaplex. There is no source code, no build, and no test suite — each top-level directory is one published action consumed by other repos as `metaplex-foundation/actions/<action-name>@v1`.
+
+## Layout convention
+
+Every action is a directory containing at minimum:
+- `action.yml` — composite action definition (`runs.using: "composite"`)
+- `README.md` — usage example and input/output reference
+
+Some actions also ship supporting assets (e.g., `code-review/prompt.md` is a multi-hundred-line prompt template kept out of `action.yml` for readability). When an action's logic or content would bloat `action.yml`, prefer a sibling file loaded at runtime via `${{ github.action_path }}` over embedding it in YAML.
+
+When adding a new action, follow that structure and add a link to the new directory in the root `README.md`.
+
+## Cross-action dependencies
+
+Some actions wrap others in this repo via `metaplex-foundation/actions/<name>@v1`. When editing one, check who calls it:
+- `start-validator` → uses `install-solana` and `install-node-with-pnpm`
+- `install-node-with-pnpm` → uses `install-node-dependencies`
+
+Because callers reference the `@v1` tag (not a local path), changes only take effect for downstream repos after the `v1` tag is moved. Local cross-references in this repo also resolve via the published tag, not the working tree.
+
+## Recurring patterns to preserve
+
+- **Cache toggle:** any action that installs or downloads something exposes a `cache: "true"` input gating an `actions/cache@v4` step. Cache keys follow `${{ runner.os }}-<name>-v<version>` or `${{ runner.os }}-<key>-${{ hashFiles(...) }}` with a fallback `restore-keys`. Match this when adding new install/cache actions.
+- **PATH export:** install actions append the tool's bin directory to `$GITHUB_PATH` and finish with a `--version` verification step.
+- **Inputs are always strings.** Booleans are passed as `"true"` / `"false"` and compared as strings (`if: inputs.cache == 'true'`).
+
+## `install-solana` base URL logic
+
+`install-solana/action.yml` selects the download host by version: `https://release.solana.com` for versions strictly below `1.18.19`, `https://release.anza.xyz` for `1.18.19` and above. The comparison uses `sort -V`. A `base_url` input overrides this. Don't simplify this branching without considering older Solana versions still in use.
+
+## `filter-matrix` quirks
+
+`filter-matrix/action.yml` does string munging on JSON: it replaces `-` with `_` in change keys to match `dorny/paths-filter` filter names (which are typically snake_case), then uses `jq` to intersect with the input matrix. The `prefix`/`suffix` inputs are concatenated onto each matrix entry before lookup. Be careful editing the `sed` pipeline — entries containing literal quotes or hyphens are sensitive to it.
+
+## Testing changes
+
+There is no automated test harness. Validate changes by:
+1. Reading the action's `README.md` example to confirm the input/output contract still holds.
+2. Running the action from a consuming repo's workflow against a branch ref (e.g. `metaplex-foundation/actions/install-solana@my-branch`) before moving the `v1` tag.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 A set of useful GitHub actions for Solana devs.
 
+- [Cache crate dependencies](./cache-crate)
+- [Cache crates dependencies](./cache-crates)
 - [Cache IDL generators](./cache-idl-generators)
 - [Cache program dependencies](./cache-program)
 - [Cache all programs dependencies](./cache-programs)
+- [Code review](./code-review)
 - [Filter matrix](./filter-matrix)
 - [Install Anchor CLI](./install-anchor-cli)
+- [Install cargo-release](./install-cargo-release)
 - [Install Node dependencies](./install-node-dependencies)
 - [Install Node with PNPM](./install-node-with-pnpm)
 - [Install Rust](./install-rust)

--- a/code-review/README.md
+++ b/code-review/README.md
@@ -95,7 +95,7 @@ jobs:
 
 To re-trigger a review without pushing a new commit, run the workflow manually with the PR number:
 
-```
+```bash
 gh workflow run code-review.yml -f pr_number=123
 ```
 

--- a/code-review/README.md
+++ b/code-review/README.md
@@ -1,0 +1,117 @@
+# Code Review
+
+Automated security and quality review for Solana programs, powered by Claude. On each PR (or manual re-run), the action posts a sticky walkthrough/summary comment and inline review comments anchored to specific findings — the CodeRabbit pattern.
+
+The review is opinionated: it focuses on Solana-program security (account validation, PDA correctness, CPI safety, arithmetic, token/rent handling, Anchor constraints) and quality regressions (new `unwrap()` on instruction paths, new `unsafe`, removed validation, weakened tests). The full curated checklist is in [`prompt.md`](./prompt.md). Per-repo invariants are appended via the `extra_instructions` input.
+
+## Quick start
+
+```yaml
+- uses: metaplex-foundation/actions/code-review@v1
+  with:
+    claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+```
+
+## Inputs
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `claude_code_oauth_token` | — | Claude Pro/Max OAuth token. Generate locally with `claude setup-token`. **Preferred.** One of this or `anthropic_api_key` is required. |
+| `anthropic_api_key` | — | Anthropic API key. Used only if `claude_code_oauth_token` is empty. |
+| `paths` | `programs/**/*.rs` | Newline-separated globs restricting which changed files the review covers. |
+| `extra_instructions` | `""` | Markdown appended to the curated baseline under a `## Repository-specific guidance` heading. Use this to encode repo-specific invariants. |
+| `model` | `claude-opus-4-7` | The Claude model. Opus is the default for review depth; `claude-sonnet-4-6` is a cheaper alternative. |
+| `pr_number` | (current PR) | Explicit PR number, used when triggering via `workflow_dispatch`. Falls back to the current PR context for `pull_request` events. |
+
+## Required permissions
+
+The consuming workflow must grant:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+```
+
+## Recommended workflow
+
+```yaml
+# .github/workflows/code-review.yml
+name: Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'programs/**/*.rs'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+concurrency:
+  group: code-review-pr-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/merge', inputs.pr_number) }}
+
+      - uses: metaplex-foundation/actions/code-review@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          pr_number: ${{ inputs.pr_number }}
+          extra_instructions: |
+            - The Authority PDA must use seeds [b"authority", mint.key()].
+            - Token transfers must use `transfer_checked`, never `transfer`.
+            - Any new instruction handler must have a corresponding test that exercises the unauthorized-caller path.
+```
+
+### Why these defaults
+
+- **`pull_request`, not `pull_request_target`** — forked PRs deliberately don't get the secret. Reviewing fork PRs requires a separate maintainer-approved flow and is out of scope for this action.
+- **`fetch-depth: 0`** — the action needs full history to compute the diff against the base.
+- **Skip drafts** — saves Claude credits while a PR is still WIP.
+- **`concurrency.cancel-in-progress: true`** — when a new commit lands, supersede the in-flight review rather than wasting credits on a stale diff.
+- **Workflow-level `paths` filter** is independent from this action's `paths` input. The workflow filter skips the run entirely; the action input narrows what Claude reviews within a run.
+
+## Manual re-run
+
+To re-trigger a review without pushing a new commit, run the workflow manually with the PR number:
+
+```
+gh workflow run code-review.yml -f pr_number=123
+```
+
+## Authentication
+
+The OAuth flow (`claude_code_oauth_token`) is preferred — it bills against a Claude Pro/Max subscription rather than per-call API credits. To set it up:
+
+1. Locally, run `claude setup-token` and authenticate as the user whose subscription should pay for reviews.
+2. Copy the generated token.
+3. Add it to the consuming repo (or org) as the secret `CLAUDE_CODE_OAUTH_TOKEN`.
+
+Use `anthropic_api_key` instead when the consuming repo can't sit under a personal Pro/Max subscription (e.g., partner orgs, contractor-run repos).
+
+## Out of scope (v1)
+
+- Reviewing PRs from forks.
+- Failing the build on `critical` findings — v1 is advisory-only.
+- Custom severity thresholds (suppress `low`, etc.).
+- Non-Rust review (TS clients, Python tooling).

--- a/code-review/action.yml
+++ b/code-review/action.yml
@@ -70,15 +70,15 @@ runs:
         src, dst = sys.argv[1], sys.argv[2]
         with open(src) as f:
             content = f.read()
+        extra = os.environ.get("EXTRA_INSTRUCTIONS", "").strip()
+        extra_block = extra if extra else "_(none — pass `extra_instructions` to the action to add repo-specific invariants here)_"
         content = (
             content
             .replace("{{REPO}}", os.environ.get("REPO", ""))
             .replace("{{PR_NUMBER}}", os.environ.get("PR_NUMBER", ""))
             .replace("{{REVIEW_PATHS}}", os.environ.get("REVIEW_PATHS", ""))
+            .replace("{{EXTRA_INSTRUCTIONS}}", extra_block)
         )
-        extra = os.environ.get("EXTRA_INSTRUCTIONS", "").strip()
-        if extra:
-            content = content.rstrip() + "\n\n## Repository-specific guidance\n\n" + extra + "\n"
         with open(dst, "w") as f:
             f.write(content)
         PYEOF

--- a/code-review/action.yml
+++ b/code-review/action.yml
@@ -99,4 +99,4 @@ runs:
         prompt: ${{ steps.prompt.outputs.prompt }}
         claude_args: |
           --model ${{ inputs.model }}
-          --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checkout:*)"
+          --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/code-review/action.yml
+++ b/code-review/action.yml
@@ -1,0 +1,102 @@
+name: Code Review
+description: Run a Solana-focused security and quality review on a PR using Claude.
+
+inputs:
+  claude_code_oauth_token:
+    description: Claude Pro/Max OAuth token (preferred). Generate locally with `claude setup-token`. One of this or `anthropic_api_key` is required.
+    required: false
+    default: ""
+  anthropic_api_key:
+    description: Anthropic API key (fallback). Used only if `claude_code_oauth_token` is empty.
+    required: false
+    default: ""
+  paths:
+    description: Newline-separated globs restricting which changed files the review covers.
+    required: false
+    default: "programs/**/*.rs"
+  extra_instructions:
+    description: Markdown appended to the curated baseline prompt under a "Repository-specific guidance" heading.
+    required: false
+    default: ""
+  model:
+    description: The Claude model to use. Passed through to the Claude CLI via `--model`.
+    required: false
+    default: "claude-opus-4-7"
+  pr_number:
+    description: PR number to review. Defaults to the current PR context. Set explicitly when triggering via `workflow_dispatch`.
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate auth
+      if: inputs.claude_code_oauth_token == '' && inputs.anthropic_api_key == ''
+      run: |
+        echo "::error::code-review action requires one of claude_code_oauth_token or anthropic_api_key to be set."
+        exit 1
+      shell: bash
+
+    - name: Resolve PR number
+      id: pr
+      env:
+        INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        if [ -n "$INPUT_PR_NUMBER" ]; then
+          echo "number=$INPUT_PR_NUMBER" >> "$GITHUB_OUTPUT"
+        elif [ -n "$EVENT_PR_NUMBER" ]; then
+          echo "number=$EVENT_PR_NUMBER" >> "$GITHUB_OUTPUT"
+        else
+          echo "::error::Could not determine PR number. Pass pr_number when triggering via workflow_dispatch."
+          exit 1
+        fi
+      shell: bash
+
+    - name: Assemble prompt
+      id: prompt
+      env:
+        REVIEW_PATHS: ${{ inputs.paths }}
+        EXTRA_INSTRUCTIONS: ${{ inputs.extra_instructions }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ steps.pr.outputs.number }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+        PROMPT_FILE="$RUNNER_TEMP/code-review-prompt.md"
+
+        python3 - "$ACTION_PATH/prompt.md" "$PROMPT_FILE" <<'PYEOF'
+        import os, sys
+        src, dst = sys.argv[1], sys.argv[2]
+        with open(src) as f:
+            content = f.read()
+        content = (
+            content
+            .replace("{{REPO}}", os.environ.get("REPO", ""))
+            .replace("{{PR_NUMBER}}", os.environ.get("PR_NUMBER", ""))
+            .replace("{{REVIEW_PATHS}}", os.environ.get("REVIEW_PATHS", ""))
+        )
+        extra = os.environ.get("EXTRA_INSTRUCTIONS", "").strip()
+        if extra:
+            content = content.rstrip() + "\n\n## Repository-specific guidance\n\n" + extra + "\n"
+        with open(dst, "w") as f:
+            f.write(content)
+        PYEOF
+
+        {
+          echo "prompt<<__PROMPT_EOF__"
+          cat "$PROMPT_FILE"
+          echo "__PROMPT_EOF__"
+        } >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - name: Run Claude code review
+      uses: anthropics/claude-code-action@v1
+      with:
+        claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
+        anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        track_progress: "true"
+        prompt: ${{ steps.prompt.outputs.prompt }}
+        claude_args: |
+          --model ${{ inputs.model }}
+          --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checkout:*)"

--- a/code-review/prompt.md
+++ b/code-review/prompt.md
@@ -96,4 +96,4 @@ Apply this checklist to every changed file in scope. Do not invent findings to f
 
 ## Repository-specific guidance
 
-(none — see `extra_instructions` input on the action invocation if your repo has appended any)
+{{EXTRA_INSTRUCTIONS}}

--- a/code-review/prompt.md
+++ b/code-review/prompt.md
@@ -6,7 +6,7 @@ You are reviewing a pull request to a Solana program repository. Your job is to 
 **Pull request:** #{{PR_NUMBER}}
 **Review scope:** files matching these globs (anything else is out of scope — do not comment on it):
 
-```
+```text
 {{REVIEW_PATHS}}
 ```
 

--- a/code-review/prompt.md
+++ b/code-review/prompt.md
@@ -1,0 +1,99 @@
+# Solana Program Code Review
+
+You are reviewing a pull request to a Solana program repository. Your job is to catch security regressions and quality issues before merge. Be the reviewer the team relies on for the things humans miss when they're tired.
+
+**Repository:** {{REPO}}
+**Pull request:** #{{PR_NUMBER}}
+**Review scope:** files matching these globs (anything else is out of scope — do not comment on it):
+
+```
+{{REVIEW_PATHS}}
+```
+
+The PR branch is checked out in the working directory. Use `gh pr diff {{PR_NUMBER}}` to see the diff and `gh pr view {{PR_NUMBER}}` for context.
+
+## How to post findings
+
+You have two channels:
+
+1. **Walkthrough / summary comment** — a single sticky comment updated as you work. Use it for the PR walkthrough (1–3 sentences on what changed) and a findings table grouped by severity. The harness manages this comment for you via the progress tracker.
+2. **Inline review comments** — one per `medium`-or-above finding, anchored to the offending lines. Use `mcp__github_inline_comment__create_inline_comment` with `confirmed: true`. Each inline comment must include: severity tag in bold (e.g. `**[HIGH]**`), the issue, the risk, and a concrete suggested fix. Quote 1–3 lines of context maximum.
+
+Do not post review text as chat messages — only as GitHub comments.
+
+## Severity tiers
+
+- `critical` — directly exploitable; loss of funds, takeover of authority, or arbitrary state mutation by an unauthorized actor.
+- `high` — security regression: a previously enforced check is missing, weakened, or bypassable.
+- `medium` — correctness issue or denial-of-service vector that doesn't immediately move funds but breaks invariants.
+- `low` — quality regression: maintainability, readability, missing documentation of an invariant.
+- `nit` — style or preference. List in the summary table only; **do not** post inline.
+
+Inline-comment threshold is `medium`. Anything `low` or `nit` belongs in the summary table only.
+
+## What to look for
+
+Apply this checklist to every changed file in scope. Do not invent findings to fill it out — if a category has no issues in this PR, skip it silently.
+
+### Account validation
+
+- Owner checks: `account.owner == &expected_program_id` for any account whose data is read or trusted. Anchor's `Account<T>` enforces this; raw `AccountInfo` does not.
+- Signer checks: every authority that should have signed must have `is_signer == true` verified.
+- Writable checks: accounts being mutated must have `is_writable == true`.
+- Account-type confusion: raw deserialization without a discriminator check (e.g., `Foo::try_from_slice(&account.data.borrow())` on an attacker-supplied account) lets a different account type be passed in.
+- Expected account count: instruction handlers that index into `accounts` by position must validate the slice length first.
+
+### PDA correctness
+
+- Canonical bump: PDAs derived for verification should use `find_program_address` (or `Pubkey::create_program_address` with a bump that was *previously* validated and stored). Trusting an attacker-supplied bump from instruction data without verification is a classic exploit.
+- Seeds match expectations: seeds in `invoke_signed` and `#[account(seeds = ..., bump)]` must match the program's intended derivation, including the order and types of seed components.
+- Seed collisions: two different account types should not be derivable from overlapping seed sets.
+
+### CPI safety
+
+- Program ID validation: before `invoke` / `invoke_signed`, the target program account's pubkey must be checked against the expected program ID constant. An attacker-supplied program account leads to arbitrary code execution.
+- Signer seeds correctness: `invoke_signed` seeds must derive the PDA whose authority is being asserted, with the correct bump.
+- No arbitrary CPI: instruction data should not control which program is invoked unless that's an explicit, audited feature.
+
+### Arithmetic
+
+- Checked math on lamports, token amounts, supplies, and any value derived from account data: `checked_add`, `checked_sub`, `checked_mul`, `checked_div`. Plain `+`, `-`, `*` on `u64` values panics on overflow in debug and silently wraps in release with overflow-checks off — verify the workspace `Cargo.toml`.
+- Cast safety: `as` between signed and unsigned types (`u64 as i64`, `i64 as u64`) and narrowing casts (`u64 as u32`) on attacker-controlled values. Use `try_into()` and handle the error.
+- Division by zero on attacker-controlled denominators.
+
+### Token & rent
+
+- SPL Token vs Token-2022 program ID: instructions that work with token accounts must validate the token program account is the expected one. Mixing them is exploitable.
+- Mint and decimals: `transfer_checked` over `transfer`. Decimals validation prevents decimal-confusion attacks.
+- Token account ownership: a `TokenAccount`'s `owner` field (the SPL owner) must be checked when authority over the tokens is being asserted.
+- Lamport drainage on close: closing an account should zero its data, transfer lamports to the intended receiver, and mark it closed. Sending lamports to an attacker-controlled account is a critical bug.
+- Rent exemption: newly created accounts must be rent-exempt.
+
+### Anchor-specific
+
+- Missing `#[account(...)]` constraints on `Accounts` structs: `mut` for accounts being modified, `signer` for authorities, `has_one` for back-references, `owner` for owner checks, `seeds` and `bump` for PDAs.
+- `init_if_needed`: re-initialization risk. Prefer `init` unless the account is genuinely shared and the handler defends against re-init by checking initialization state.
+- `close = receiver`: ensure `receiver` is constrained to a known authority, not an attacker-supplied account.
+- `realloc`: validate the new size and ensure rent is topped up; check for zeroing of newly added bytes.
+
+### Quality regressions
+
+- New `unwrap()`, `expect()`, or `panic!` on instruction-handler paths — these are denial-of-service vectors and abort the transaction in attacker-favorable ways.
+- New `unsafe` blocks in program code.
+- New `#[allow(...)]` attributes suppressing security-relevant lints.
+- New or upgraded Cargo dependencies that haven't been audited (call out the dep, don't block — humans decide).
+- Removed or weakened validation steps compared to the base branch.
+- Removed or weakened tests, especially for instruction-handler edge cases.
+- Public functions or `#[derive(...)]`s exposing internals that shouldn't cross a trust boundary.
+
+## Output discipline
+
+- If the PR is clean, post a short summary saying so. Do not invent findings.
+- Quote line numbers and file paths exactly. Verify each before posting; a finding on the wrong line is worse than no finding.
+- Inline comments should be self-contained — a reader who hasn't read the summary should still understand the issue.
+- Distinguish "this is wrong" from "this could be clearer." The first is a finding, the second is a nit.
+- When you suggest a fix, write it as code, not prose. A diff or a code block beats a paragraph.
+
+## Repository-specific guidance
+
+(none — see `extra_instructions` input on the action invocation if your repo has appended any)

--- a/docs/plans/2026-05-06-code-review-action-design.md
+++ b/docs/plans/2026-05-06-code-review-action-design.md
@@ -1,0 +1,131 @@
+# Design — `code-review` action
+
+**Date:** 2026-05-06
+**Status:** Validated, ready for implementation
+
+## Purpose
+
+Add a new GitHub Action, `metaplex-foundation/actions/code-review`, that runs an automated security- and quality-focused review on PRs targeting Solana programs and posts findings back on the PR. The action is consumed by Metaplex program repos to catch security regressions (missing signer/owner checks, PDA bump misuse, unchecked arithmetic, CPI safety, Anchor-constraint gaps) before merge.
+
+## Architecture
+
+Thin composite wrapper around `anthropics/claude-code-action@v1`. Our value-add is concentrated in three places: the curated Solana security review prompt, sensible PR defaults, and a stable entry point under the `metaplex-foundation/actions` namespace.
+
+**Files added under `code-review/`:**
+
+- `action.yml` — composite action definition.
+- `prompt.md` — the curated baseline review prompt. Lives in a separate file so it can be edited and diffed without YAML escaping noise.
+- `README.md` — usage examples (PR trigger + manual re-run), input reference, required permissions.
+
+The root `README.md` gets a link to `code-review`. While editing it, also backfill the missing entries for `cache-crate`, `cache-crates`, and `install-cargo-release`.
+
+## Composite steps
+
+1. **Validate auth** — fail fast with a clear error if neither `claude_code_oauth_token` nor `anthropic_api_key` is set.
+2. **Assemble prompt** — copy `${GITHUB_ACTION_PATH}/prompt.md` to `${RUNNER_TEMP}/review-prompt.md`, append the consumer's `extra_instructions` under a `## Repository-specific guidance` heading, and inject the `paths` value into the prompt so Claude knows the review scope. Output the temp path.
+3. **Run Claude review** — `uses: anthropics/claude-code-action@v1` with the assembled prompt, auth, model, sticky-comment flag, and `pr_number` (for `workflow_dispatch`).
+
+`anthropics/claude-code-action` is pinned to `@v1`. Don't track `@main`.
+
+## Inputs
+
+| Input | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `claude_code_oauth_token` | one-of-two | — | Pro/Max OAuth token, generated locally via `claude setup-token`. Preferred. |
+| `anthropic_api_key` | one-of-two | — | API key fallback. Used only if OAuth token is empty. |
+| `paths` | no | `programs/**/*.rs` | Glob (or newline-separated globs) restricting which changed files the review covers. |
+| `extra_instructions` | no | `""` | Markdown appended to the curated baseline — repo-specific invariants. |
+| `model` | no | `claude-opus-4-7` | Override if a repo wants cheaper Sonnet reviews. Opus is the default; security review benefits most from reasoning depth. |
+| `pr_number` | no | — | Explicit PR number, used when triggered via `workflow_dispatch`. Falls back to the current PR context when running on `pull_request`. |
+
+No outputs — the action's effect is the comments it posts.
+
+## Review surface
+
+The prompt instructs Claude to behave like a CodeRabbit-style reviewer:
+
+- **Sticky summary comment** — one comment per PR, replaced on each push (`use_sticky_comment: true`). Contains a short walkthrough plus a findings table grouped by severity.
+- **Inline review comments** — one per `medium`-or-above finding, anchored to the offending lines via the GitHub Reviews API. Each includes severity tag, the issue, the risk, and a suggested fix. Quotes 1–3 lines of context max.
+
+Severity tiers: `critical` (exploitable / fund loss), `high` (security regression, missing required check), `medium` (correctness or DoS), `low` (quality / maintainability), `nit` (suppressed by default — listed in summary, not posted inline).
+
+## Prompt baseline (`prompt.md`)
+
+The curated checklist covers Solana-program security and quality:
+
+- **Account validation** — owner checks, signer checks, writable checks, account-type confusion via raw deserialize without discriminator, expected-account-count.
+- **PDA correctness** — canonical bump (`find_program_address`) vs attacker-controlled bump (`create_program_address` with passed-in bump), seeds match, PDA collision footguns.
+- **CPI safety** — program ID validation before `invoke`, correct signer seeds for `invoke_signed`, no arbitrary CPI to user-controlled programs.
+- **Arithmetic** — checked math on lamports / token amounts / supply, cast safety between signed and unsigned, overflow on attacker-controlled inputs.
+- **Token & rent** — SPL Token / Token-2022 program ID validation, mint and decimals checks, lamport drainage via close-account, rent-exemption on new accounts.
+- **Anchor-specific** — missing `#[account(...)]` constraints (`mut`, `signer`, `has_one`, `owner`, `seeds`, `bump`), `init_if_needed` re-init risk, `close = receiver` correctness.
+- **Quality regressions** — new `unwrap()`/`expect()` in instruction paths, new `unsafe`, new `#[allow(...)]`, new unaudited Cargo deps, removed validation, weakened tests.
+
+The prompt closes with a `## Repository-specific guidance` section populated from `extra_instructions`.
+
+## Consumer workflow
+
+```yaml
+# .github/workflows/code-review.yml
+name: Code Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths: ['programs/**/*.rs']
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: number
+
+permissions:
+  pull-requests: write
+  contents: read
+  issues: write
+
+concurrency:
+  group: code-review-pr-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/merge', inputs.pr_number) }}
+      - uses: metaplex-foundation/actions/code-review@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          pr_number: ${{ inputs.pr_number }}
+          extra_instructions: |
+            - The Authority PDA must use seeds [b"authority", mint.key()].
+            - Use transfer_checked, not transfer.
+```
+
+Notes called out in the README:
+
+- **`pull_request`, not `pull_request_target`** — forked PRs deliberately don't get the secret. Reviewing fork PRs requires a separate maintainer-approved flow; out of scope for v1.
+- **`fetch-depth: 0`** — required so the action can compute the diff against the base.
+- **Skip drafts** — saves credits on WIP work.
+- **Concurrency cancel** — supersede an in-flight review when a new commit lands.
+- **Workflow-level `paths`** is independent from the action's `paths` input. Workflow-level skips the run entirely; action-level narrows what Claude reviews within a run.
+
+## Testing & rollout
+
+1. **Self-test workflow** in this repo, `workflow_dispatch`-only, that runs `./code-review` (local action ref) against a hand-picked PR in a real Solana repo. Iterate on the prompt without moving the `v1` tag. Gated on a maintainer-only secret so randos don't burn the org's Claude quota.
+2. **Pilot in one repo** — point one Metaplex program repo at `metaplex-foundation/actions/code-review@<branch>` for ~1 week before promoting `v1`. Standard branch-ref pattern from `CLAUDE.md`.
+3. **Prompt-tuning loop** — when a reviewer disagrees with a finding (false positive or miss), the fix goes upstream into `prompt.md` if generalizable, otherwise into the consuming repo's `extra_instructions`. The discipline is in that line.
+4. **Rollback** — consumers can pin `@<sha>` instead of `@v1` while we fix forward. No secrets need rotating.
+
+## Out of scope for v1
+
+- Fork PR support
+- Custom severity thresholds (e.g., suppress `low` entirely)
+- Failing the build on `critical` findings (advisory-only for v1)
+- TS client / non-Rust review
+
+These are the obvious next iterations once v1 is in production and we have feedback.


### PR DESCRIPTION
## Summary

- New composite action `code-review/` that wraps `anthropics/claude-code-action@v1` with a curated Solana-program security and quality review prompt, surfacing findings on the PR as a sticky walkthrough/summary comment plus inline review comments (CodeRabbit-style).
- Inputs: `claude_code_oauth_token` (preferred) or `anthropic_api_key`, plus `paths`, `extra_instructions`, `model`, and `pr_number` (for `workflow_dispatch` re-runs).
- Curated checklist in `code-review/prompt.md` covers account validation, PDA correctness, CPI safety, arithmetic, token/rent handling, Anchor-specific footguns, and quality regressions. Repo-specific invariants are appended via `extra_instructions`.
- Adds `CLAUDE.md` for future Claude Code sessions, a validated design doc under `docs/plans/`, and backfills missing entries (`cache-crate`, `cache-crates`, `install-cargo-release`) in the root `README.md`.

## Test plan

- [ ] `python3 -c "import yaml; yaml.safe_load(open('code-review/action.yml'))"` parses cleanly (verified locally).
- [ ] Add `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) as a repo/org secret in a pilot consumer repo.
- [ ] Drop in the workflow from `code-review/README.md`, pointed at `metaplex-foundation/actions/code-review@add-code-review-action` for testing.
- [ ] Trigger via `workflow_dispatch` with a known PR number; verify the sticky walkthrough comment appears and inline comments anchor correctly.
- [ ] Open a draft PR with a deliberate Solana footgun (missing signer check, unchecked arithmetic on lamports) and confirm Claude flags it at the right severity.
- [ ] Once the prompt is dialed in, move the `v1` tag.

## Out of scope (v1)

- Reviewing PRs from forks (secrets are intentionally not exposed to fork PRs).
- Failing the build on `critical` findings — advisory-only for v1.
- Custom severity thresholds / non-Rust review.