### PR TITLE
verified-build, verify-program: add solana-version lookup for base-image

### DIFF
--- a/solana-verify-base-images.json
+++ b/solana-verify-base-images.json
@@ -1,0 +1,6 @@
+{
+  "$comment": "Maps Solana versions to digest-pinned solana-verifiable-build images. Consumed by the verified-build and verify-program composite actions when a caller passes `solana-version` without an explicit `base-image`. Adding a new entry requires verifying the digest against the official solanafoundation/solana-verifiable-build registry: `docker buildx imagetools inspect solanafoundation/solana-verifiable-build:<TAG> --format '{{ .Manifest.Digest }}'`. Keep this file sorted by Solana version (newest first).",
+  "images": {
+    "1.18.26": "solanafoundation/solana-verifiable-build@sha256:ec2e20e1f80607150a71e4c72adfe64be24347ed0b4fb741c32b34eaf7549a25"
+  }
+}

--- a/verified-build/README.md
+++ b/verified-build/README.md
@@ -11,14 +11,15 @@ Requires `solana-verify` to be installed first (see [`install-solana-verify`](..
   with:
     library-name: mpl_hybrid
     package: mpl-hybrid-program
-    base-image: solanafoundation/solana-verifiable-build@sha256:ec2e20e1f80607150a71e4c72adfe64be24347ed0b4fb741c32b34eaf7549a25
+    solana-version: 1.18.26
     output-dir: programs/.bin
 ```
 
 - Inputs:
   - `library-name`: Cargo library name (matches `[lib].name` in the program's `Cargo.toml`). **Required**.
   - `package`: Cargo package name passed after `--`. Required when the workspace has multiple members that could emit the same library filename.
-  - `base-image`: Docker base image used by `solana-verify build`. Must be digest-pinned (`<image>@sha256:<digest>`) so a mutable upstream tag cannot change the resulting `.so` hash between runs. Pin this to match the Solana version that produced the on-chain program. Leave empty to use `solana-verify`'s default image.
+  - `solana-version`: Solana version that produced the on-chain program. The action resolves this against [`solana-verify-base-images.json`](../solana-verify-base-images.json) at the actions repo root and uses the matching digest-pinned image. The simplest way to get a reproducible verifier image for a known Solana release. Pass `base-image` to override.
+  - `base-image`: Direct digest-pinned base image (`<image>@sha256:<digest>`). Takes precedence over `solana-version`. Use this when verifying against a Solana version that is not yet in the lookup table. Leave both empty to use `solana-verify`'s default image.
   - `allow-mutable-tag`: Allow `base-image` to use a mutable tag instead of a digest pin. Defaults to `false`. Mutable tags can be re-pushed by the registry owner, so two builds at the same git commit may produce different binaries. Only set this to `true` if you accept that risk.
   - `working-directory`: Directory to run the build from. Defaults to `.`.
   - `output-dir`: Directory (relative to `working-directory`) to copy the built `.so` into. Leave empty to keep the artifact in `target/deploy/<library-name>.so` only.
@@ -28,34 +29,43 @@ Requires `solana-verify` to be installed first (see [`install-solana-verify`](..
 
 ## Pinning the base image
 
-The action requires `base-image` to be digest-pinned because [`solana-verify build`](https://github.com/Ellipsis-Labs/solana-verifiable-build) builds the program inside the chosen image — a mutable tag like `:1.18.26` can be re-pushed by the registry owner, so two CI runs at the same git commit can produce different `.so` files. Find the current digest for an image with:
+The action requires `base-image` to be digest-pinned because [`solana-verify build`](https://github.com/Ellipsis-Labs/solana-verifiable-build) builds the program inside the chosen image — a mutable tag like `:1.18.26` can be re-pushed by the registry owner, so two CI runs at the same git commit can produce different `.so` files. See [mpl-hybrid PR #26](https://github.com/metaplex-foundation/mpl-hybrid/pull/26) for the audit finding that originated this pattern.
+
+For callers on a Solana version listed in [`solana-verify-base-images.json`](../solana-verify-base-images.json), the simplest pattern is `solana-version: <X.Y.Z>` and let the action pick the right digest:
+
+```yaml
+- uses: metaplex-foundation/actions/verified-build@v1
+  with:
+    library-name: mpl_hybrid
+    package: mpl-hybrid-program
+    solana-version: 1.18.26
+```
+
+For other versions or to override the lookup, pass `base-image` directly:
 
 ```bash
-docker buildx imagetools inspect solanafoundation/solana-verifiable-build:1.18.26 \
+docker buildx imagetools inspect solanafoundation/solana-verifiable-build:1.18.30 \
   --format '{{ .Manifest.Digest }}'
 ```
 
-Hard-code the result in the caller workflow's `env:` block — **not** in `.github/.env` — and treat updates to it as security-relevant review items. Loading the digest from `.github/.env` is unsafe because any PR can edit that file and silently swap the verifier image; see [mpl-hybrid PR #26](https://github.com/metaplex-foundation/mpl-hybrid/pull/26) for the audit finding that originated this pattern.
-
 ```yaml
-env:
-  SOLANA_VERIFY_BASE_IMAGE: solanafoundation/solana-verifiable-build@sha256:ec2e20e1f80607150a71e4c72adfe64be24347ed0b4fb741c32b34eaf7549a25
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: metaplex-foundation/actions/verified-build@v1
-        with:
-          library-name: mpl_hybrid
-          package: mpl-hybrid-program
-          base-image: ${{ env.SOLANA_VERIFY_BASE_IMAGE }}
+- uses: metaplex-foundation/actions/verified-build@v1
+  with:
+    library-name: mpl_hybrid
+    package: mpl-hybrid-program
+    base-image: solanafoundation/solana-verifiable-build@sha256:<digest>
 ```
 
-If the workflow also grep-loads `.github/.env` into `$GITHUB_ENV`, use an allowlist that excludes `SOLANA_VERIFY_BASE_IMAGE` so a future re-introduction can't override the workflow-level pin:
+When passing `base-image` directly, hard-code it in the caller workflow's `env:` block — **not** in `.github/.env` — and treat updates as security-relevant review items. Loading the digest from `.github/.env` is unsafe because any PR can edit that file and silently swap the verifier image.
+
+If the workflow grep-loads `.github/.env` into `$GITHUB_ENV`, use an allowlist that excludes any image-related key:
 
 ```yaml
 - run: |
     grep -E '^(CARGO_TERM_COLOR|RUST_VERSION|SOLANA_VERSION|SOLANA_VERIFY_VERSION|PROGRAMS)=' \
       .github/.env >> "$GITHUB_ENV"
 ```
+
+### Adding a new Solana version to the lookup
+
+Update [`solana-verify-base-images.json`](../solana-verify-base-images.json) with the digest from `docker buildx imagetools inspect`. The action's resolution error message lists the currently known versions, so an actionable failure is the signal to add an entry.

--- a/verified-build/action.yml
+++ b/verified-build/action.yml
@@ -7,13 +7,22 @@ inputs:
   package:
     description: Cargo package name passed to `solana-verify build` after `--`. Required when the workspace has multiple members that could emit the same library filename
     required: false
+  solana-version:
+    description: |
+      Solana version that produced the on-chain program. When `base-image` is
+      not provided, the action resolves this against `solana-verify-base-images.json`
+      at the actions repo root and uses the matching digest-pinned image.
+      Pass `base-image` explicitly to override the lookup or to use a version
+      that is not yet in the table
+    required: false
   base-image:
     description: |
       Docker base image for the deterministic build. Must be digest-pinned
       (e.g. `solanafoundation/solana-verifiable-build@sha256:<digest>`) so a
       mutable upstream tag cannot change the resulting `.so` hash between
-      runs. Leave empty to use `solana-verify`'s default image. Set
-      `allow-mutable-tag: true` to bypass the format check (not recommended)
+      runs. Takes precedence over `solana-version`. Leave both empty to use
+      `solana-verify`'s default image. Set `allow-mutable-tag: true` to bypass
+      the format check (not recommended)
     required: false
   allow-mutable-tag:
     description: |
@@ -48,12 +57,30 @@ runs:
       env:
         LIBRARY_NAME: ${{ inputs.library-name }}
         PACKAGE_NAME: ${{ inputs.package }}
+        SOLANA_VERSION: ${{ inputs.solana-version }}
         BASE_IMAGE: ${{ inputs.base-image }}
         ALLOW_MUTABLE_TAG: ${{ inputs.allow-mutable-tag }}
         OUTPUT_DIR: ${{ inputs.output-dir }}
         EXTRA_ARGS: ${{ inputs.extra-args }}
+        ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
+
+        # Resolve base-image: explicit input wins, otherwise look up by
+        # solana-version against the table at the actions repo root.
+        if [ -z "${BASE_IMAGE}" ] && [ -n "${SOLANA_VERSION}" ]; then
+          LOOKUP_FILE="${ACTION_PATH%/}/../solana-verify-base-images.json"
+          if [ ! -f "${LOOKUP_FILE}" ]; then
+            echo "::error::solana-version lookup table not found at ${LOOKUP_FILE}"
+            exit 1
+          fi
+          BASE_IMAGE=$(jq -r --arg v "${SOLANA_VERSION}" '.images[$v] // empty' "${LOOKUP_FILE}")
+          if [ -z "${BASE_IMAGE}" ]; then
+            KNOWN=$(jq -r '.images | keys | join(", ")' "${LOOKUP_FILE}")
+            echo "::error::no known digest for solana-version '${SOLANA_VERSION}'. Pass 'base-image' explicitly or add an entry to solana-verify-base-images.json. Known versions: ${KNOWN}"
+            exit 1
+          fi
+        fi
 
         # Reject mutable Docker tags by default. A PR-controlled tag (or a
         # re-pushed upstream tag) can swap the verified-build image and

--- a/verify-program/README.md
+++ b/verify-program/README.md
@@ -36,7 +36,7 @@ Run one of three [`solana-verify`](https://github.com/Ellipsis-Labs/solana-verif
     rpc-url: ${{ secrets.MAINNET_RPC }}
     library-name: mpl_hybrid
     package: mpl-hybrid-program
-    base-image: solanafoundation/solana-verifiable-build@sha256:ec2e20e1f80607150a71e4c72adfe64be24347ed0b4fb741c32b34eaf7549a25
+    solana-version: 1.18.26
 ```
 
 ## Mode: `export-pda-tx` (Squads / multisig — phase 1)
@@ -53,7 +53,7 @@ Run during the deploy. Generates the base58 PDA-upload transaction for the multi
     library-name: bubblegum
     package: bubblegum
     mount-path: programs/bubblegum
-    base-image: solanafoundation/solana-verifiable-build@sha256:ec2e20e1f80607150a71e4c72adfe64be24347ed0b4fb741c32b34eaf7549a25
+    solana-version: 1.18.26
     output-file: verify-pda-tx.b58
 
 - uses: actions/upload-artifact@v4
@@ -79,7 +79,7 @@ Run after the multisig executes the transaction from phase 1. Rebuilds the progr
     library-name: bubblegum
     package: bubblegum
     mount-path: programs/bubblegum
-    base-image: solanafoundation/solana-verifiable-build@sha256:ec2e20e1f80607150a71e4c72adfe64be24347ed0b4fb741c32b34eaf7549a25
+    solana-version: 1.18.26
     submit-remote: true
 ```
 
@@ -99,9 +99,6 @@ on:
         required: true
         default: submit-remote-job
         options: [export-pda-tx, submit-remote-job]
-
-env:
-  SOLANA_VERIFY_BASE_IMAGE: solanafoundation/solana-verifiable-build@sha256:ec2e20e1f80607150a71e4c72adfe64be24347ed0b4fb741c32b34eaf7549a25
 
 jobs:
   verify:
@@ -124,7 +121,7 @@ jobs:
           library-name: bubblegum
           package: bubblegum
           mount-path: programs/bubblegum
-          base-image: ${{ env.SOLANA_VERIFY_BASE_IMAGE }}
+          solana-version: 1.18.26
           submit-remote: true
 
       - if: inputs.mode == 'export-pda-tx'
@@ -150,7 +147,8 @@ Inputs are organized by which mode(s) they apply to. The mode is validated in th
 | `package` | no | — | Cargo package name forwarded after `--`. Required when the workspace has multiple members that emit the same library filename. |
 | `mount-path` | yes | `.` | Path inside the repo to mount into the verifier container. Use e.g. `programs/bubblegum` when the Cargo workspace is nested. |
 | `working-directory` | yes | `.` | Directory `solana-verify` runs from. |
-| `base-image` | no | `solana-verify`'s default | Must be digest-pinned (`<image>@sha256:<64 hex>`). Set `allow-mutable-tag: true` to bypass. |
+| `solana-version` | no | — | Solana version that produced the on-chain program. Resolved against [`solana-verify-base-images.json`](../solana-verify-base-images.json) to a digest-pinned image. Use this for any version present in the table; otherwise pass `base-image`. |
+| `base-image` | no | derived from `solana-version` if set, else `solana-verify`'s default | Direct digest-pinned image. Takes precedence over `solana-version`. Must match `<image>@sha256:<64 hex>` unless `allow-mutable-tag: true`. |
 | `allow-mutable-tag` | yes | `false` | Allow a mutable tag for `base-image` (not recommended). |
 | `init-cli-config` | yes | `true` | Whether to run `solana config set` before `solana-verify`. Required for `solana-verify 0.4.15`'s PDA upload path. |
 
@@ -193,6 +191,7 @@ Inputs are organized by which mode(s) they apply to. The mode is validated in th
 |---|---|---|
 | `program-id` | all | Resolved program ID (pubkey). |
 | `uploader` | all | Resolved uploader pubkey. Useful when the action derived it from `keypair`. |
+| `base-image` | all | Resolved digest-pinned base image (from `base-image` input or `solana-version` lookup). Empty when neither was set. |
 | `tx-file` | `export-pda-tx` | Path of the base58 PDA-upload transaction file. |
 | `tx` | `export-pda-tx` | The base58 PDA-upload transaction itself, suitable for piping into downstream steps. |
 | `local-hash` | `submit-remote-job` | Local executable hash from the deterministic rebuild. |
@@ -206,27 +205,24 @@ When `repo-visibility: private`, `submit-remote` defaults to `false` because the
 
 The action requires `base-image` to be digest-pinned because a mutable tag like `:1.18.26` can be re-pushed by the registry owner, which would silently change the verifier's hash and either falsely match or falsely diverge from the on-chain program. The deploy job that uploads the verified-build PDA runs with the deployer keypair on disk, so a swapped image is also a foothold for a supply-chain attacker — see [mpl-hybrid PR #26](https://github.com/metaplex-foundation/mpl-hybrid/pull/26) for the audit finding that originated this pattern.
 
-Find the current digest for an image with:
+For callers on a Solana version listed in [`solana-verify-base-images.json`](../solana-verify-base-images.json), the simplest pattern is `solana-version: <X.Y.Z>` and let the action pick the right digest. For other versions or to override the lookup, find the digest with:
 
 ```bash
-docker buildx imagetools inspect solanafoundation/solana-verifiable-build:1.18.26 \
+docker buildx imagetools inspect solanafoundation/solana-verifiable-build:1.18.30 \
   --format '{{ .Manifest.Digest }}'
 ```
 
-Hard-code the result in the caller workflow's `env:` block — **not** in `.github/.env`, since any PR can edit that file and swap the image:
-
-```yaml
-env:
-  SOLANA_VERIFY_BASE_IMAGE: solanafoundation/solana-verifiable-build@sha256:ec2e20e1f80607150a71e4c72adfe64be24347ed0b4fb741c32b34eaf7549a25
-```
-
-If the workflow also grep-loads `.github/.env` into `$GITHUB_ENV`, exclude `SOLANA_VERIFY_BASE_IMAGE` from the allowlist so a re-introduced entry cannot override the workflow-level pin (`$GITHUB_ENV` wins over `env:` for subsequent steps):
+and pass `base-image` directly. Hard-code that value in the caller workflow's `env:` block — **not** in `.github/.env`, since any PR can edit that file and swap the image. If the workflow grep-loads `.github/.env` into `$GITHUB_ENV`, exclude any image-related key from the allowlist:
 
 ```yaml
 - run: |
     grep -E '^(RUST_VERSION|DEPLOY_SOLANA_VERSION|SOLANA_VERIFY_VERSION)=' \
       .github/.env >> "$GITHUB_ENV"
 ```
+
+### Adding a new Solana version to the lookup
+
+Update [`solana-verify-base-images.json`](../solana-verify-base-images.json) with the digest from `docker buildx imagetools inspect`. The action's resolution error message lists the currently known versions, so an actionable failure is the signal to add an entry.
 
 ## Notes
 

--- a/verify-program/action.yml
+++ b/verify-program/action.yml
@@ -53,13 +53,21 @@ inputs:
     required: true
     default: "."
 
+  solana-version:
+    description: |
+      Solana version that produced the on-chain program. When `base-image` is
+      not provided, the action resolves this against `solana-verify-base-images.json`
+      at the actions repo root and uses the matching digest-pinned image.
+      Pass `base-image` explicitly to override the lookup or to use a version
+      that is not yet in the table
+    required: false
   base-image:
     description: |
       Docker base image used by `solana-verify`. Must be digest-pinned
       (`<image>@sha256:<digest>`) so a mutable upstream tag cannot change the
-      hash the verifier computes. Leave empty to use `solana-verify`'s default
-      image. Set `allow-mutable-tag: true` to bypass the format check (not
-      recommended)
+      hash the verifier computes. Takes precedence over `solana-version`.
+      Leave both empty to use `solana-verify`'s default image. Set
+      `allow-mutable-tag: true` to bypass the format check (not recommended)
     required: false
   allow-mutable-tag:
     description: |
@@ -143,6 +151,9 @@ outputs:
   uploader:
     description: The resolved uploader pubkey used for the PDA / remote submit
     value: ${{ steps.resolve.outputs.uploader }}
+  base-image:
+    description: The resolved digest-pinned base image (from `base-image` input or `solana-version` lookup)
+    value: ${{ steps.resolve.outputs.base-image }}
   tx-file:
     description: Path of the base58 PDA-upload transaction file produced in `export-pda-tx` mode
     value: ${{ steps.export.outputs.tx-file }}
@@ -172,8 +183,10 @@ runs:
         INPUT_COMMIT_HASH: ${{ inputs.commit-hash }}
         INPUT_REPO_VISIBILITY: ${{ inputs.repo-visibility }}
         INPUT_SUBMIT_REMOTE: ${{ inputs.submit-remote }}
+        INPUT_SOLANA_VERSION: ${{ inputs.solana-version }}
         INPUT_BASE_IMAGE: ${{ inputs.base-image }}
         INPUT_ALLOW_MUTABLE_TAG: ${{ inputs.allow-mutable-tag }}
+        ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
 
@@ -185,14 +198,31 @@ runs:
             ;;
         esac
 
+        # Resolve base-image: explicit input wins, otherwise look up by
+        # solana-version against the table at the actions repo root.
+        BASE_IMAGE="${INPUT_BASE_IMAGE}"
+        if [ -z "${BASE_IMAGE}" ] && [ -n "${INPUT_SOLANA_VERSION}" ]; then
+          LOOKUP_FILE="${ACTION_PATH%/}/../solana-verify-base-images.json"
+          if [ ! -f "${LOOKUP_FILE}" ]; then
+            echo "::error::solana-version lookup table not found at ${LOOKUP_FILE}"
+            exit 1
+          fi
+          BASE_IMAGE=$(jq -r --arg v "${INPUT_SOLANA_VERSION}" '.images[$v] // empty' "${LOOKUP_FILE}")
+          if [ -z "${BASE_IMAGE}" ]; then
+            KNOWN=$(jq -r '.images | keys | join(", ")' "${LOOKUP_FILE}")
+            echo "::error::no known digest for solana-version '${INPUT_SOLANA_VERSION}'. Pass 'base-image' explicitly or add an entry to solana-verify-base-images.json. Known versions: ${KNOWN}"
+            exit 1
+          fi
+        fi
+
         # Reject mutable Docker tags by default. A PR-controlled tag (or a
         # re-pushed upstream tag) can swap the verifier image and silently
         # produce a hash that no longer matches the on-chain program.
-        if [ -n "${INPUT_BASE_IMAGE}" ] && [[ ! "${INPUT_BASE_IMAGE}" =~ ^[^@[:space:]]+@sha256:[a-f0-9]{64}$ ]]; then
+        if [ -n "${BASE_IMAGE}" ] && [[ ! "${BASE_IMAGE}" =~ ^[^@[:space:]]+@sha256:[a-f0-9]{64}$ ]]; then
           if [ "${INPUT_ALLOW_MUTABLE_TAG}" = "true" ]; then
-            echo "::warning::base-image '${INPUT_BASE_IMAGE}' is not digest-pinned (allow-mutable-tag=true). Verification may drift from the on-chain hash."
+            echo "::warning::base-image '${BASE_IMAGE}' is not digest-pinned (allow-mutable-tag=true). Verification may drift from the on-chain hash."
           else
-            echo "::error::base-image '${INPUT_BASE_IMAGE}' must be digest-pinned (e.g. <image>@sha256:<digest>). Pass allow-mutable-tag: true to bypass."
+            echo "::error::base-image '${BASE_IMAGE}' must be digest-pinned (e.g. <image>@sha256:<digest>). Pass allow-mutable-tag: true to bypass."
             exit 1
           fi
         fi
@@ -308,6 +338,7 @@ runs:
         printf 'repo-url=%s\n'       "${REPO_URL}"       >> "${GITHUB_OUTPUT}"
         printf 'commit-hash=%s\n'    "${COMMIT_HASH}"    >> "${GITHUB_OUTPUT}"
         printf 'submit-remote=%s\n'  "${SUBMIT_REMOTE}"  >> "${GITHUB_OUTPUT}"
+        printf 'base-image=%s\n'     "${BASE_IMAGE}"     >> "${GITHUB_OUTPUT}"
       shell: bash
 
     # solana-verify 0.4.15 unconditionally loads ~/.config/solana/cli/config.yml
@@ -343,7 +374,7 @@ runs:
         LIBRARY_NAME: ${{ inputs.library-name }}
         PACKAGE_NAME: ${{ inputs.package }}
         MOUNT_PATH: ${{ inputs.mount-path }}
-        BASE_IMAGE: ${{ inputs.base-image }}
+        BASE_IMAGE: ${{ steps.resolve.outputs.base-image }}
       run: |
         set -euo pipefail
 
@@ -383,7 +414,7 @@ runs:
         LIBRARY_NAME: ${{ inputs.library-name }}
         PACKAGE_NAME: ${{ inputs.package }}
         MOUNT_PATH: ${{ inputs.mount-path }}
-        BASE_IMAGE: ${{ inputs.base-image }}
+        BASE_IMAGE: ${{ steps.resolve.outputs.base-image }}
         OUTPUT_FILE: ${{ inputs.output-file }}
         EMIT_SUMMARY: ${{ inputs.emit-summary }}
         ENCODING: ${{ inputs.encoding }}
@@ -466,7 +497,7 @@ runs:
         LIBRARY_NAME: ${{ inputs.library-name }}
         PACKAGE_NAME: ${{ inputs.package }}
         MOUNT_PATH: ${{ inputs.mount-path }}
-        BASE_IMAGE: ${{ inputs.base-image }}
+        BASE_IMAGE: ${{ steps.resolve.outputs.base-image }}
       run: |
         set -euo pipefail
 


### PR DESCRIPTION
Adds a `solana-version` input to both actions that resolves against a new `solana-verify-base-images.json` table at the actions repo root. The explicit `base-image` input still wins; the table is the convenient default for callers on a known Solana release.

Eliminates per-repo duplication of the verifier image digest -- mpl-hybrid and bubblegum would otherwise declare the same digest string in multiple workflow `env:` blocks. The table now lives in one PR-reviewed location that flows through to all consumers.

Threat model: a malicious PR editing a caller's `.env` SOLANA_VERSION could steer the action to a different table entry, but only to a known-digest entry -- not an arbitrary attacker-controlled image. The blast radius is bounded to known table entries, which fail the on-chain hash compare loudly when wrong. Materially safer than the original PR #26 finding.

Smoke-tested 5 cases: known version -> resolved, unknown version -> error with the known-versions list, base-image override wins over solana-version, neither set -> empty (solana-verify default), only base-image set -> unchanged from before.