### PR TITLE
verified-build: add more Solana base image lookups

### DIFF
--- a/solana-verify-base-images.json
+++ b/solana-verify-base-images.json
@@ -1,7 +1,10 @@
 {
   "$comment": "Maps Solana versions to digest-pinned solana-verifiable-build images. Consumed by the verified-build and verify-program composite actions when a caller passes `solana-version` without an explicit `base-image`. Adding a new entry requires verifying the digest against the official solanafoundation/solana-verifiable-build registry: `docker buildx imagetools inspect solanafoundation/solana-verifiable-build:<TAG> --format '{{ .Manifest.Digest }}'`. Keep this file sorted by Solana version (newest first).",
   "images": {
+    "2.3.5": "solanafoundation/solana-verifiable-build@sha256:c4d81ef3f4d540706988bca249ca8d827ab4c96c567f92c49d0d4a9a7a9337de",
     "1.18.26": "solanafoundation/solana-verifiable-build@sha256:ec2e20e1f80607150a71e4c72adfe64be24347ed0b4fb741c32b34eaf7549a25",
-    "1.18.22": "solanafoundation/solana-verifiable-build@sha256:7804e1076ef24d4840f4fec24c88b5be8008e947cad2705516666a9f24b39de3"
+    "1.18.22": "solanafoundation/solana-verifiable-build@sha256:7804e1076ef24d4840f4fec24c88b5be8008e947cad2705516666a9f24b39de3",
+    "1.18.21": "solanafoundation/solana-verifiable-build@sha256:d72ae60cb3890bcf444ab9f626e6db380235a2c0ef1e8aee1bc530fe3633c4be",
+    "1.18.19": "solanafoundation/solana-verifiable-build@sha256:25e4973b5ccb7d8eca1cc1e90fe07edb7a799075c78ac5a91cc4ff95fb4f3ec3"
   }
 }


### PR DESCRIPTION
## Summary
- Add digest-pinned `solanafoundation/solana-verifiable-build` images for Solana `2.3.5`, `1.18.21`, and `1.18.19`.
- Keeps verifier image selection centralized in the actions repo instead of allowing downstream PR-controlled `.github/.env` values.

## Test plan
- Validated JSON with `jq`.
- Verified each digest with `docker buildx imagetools inspect` against the official `solanafoundation/solana-verifiable-build` tags.