### PR TITLE
verified-build: add solana-verifiable-build 3.1.14 base image lookup

### DIFF
--- a/solana-verify-base-images.json
+++ b/solana-verify-base-images.json
@@ -1,6 +1,7 @@
 {
   "$comment": "Maps Solana versions to digest-pinned solana-verifiable-build images. Consumed by the verified-build and verify-program composite actions when a caller passes `solana-version` without an explicit `base-image`. Adding a new entry requires verifying the digest against the official solanafoundation/solana-verifiable-build registry: `docker buildx imagetools inspect solanafoundation/solana-verifiable-build:<TAG> --format '{{ .Manifest.Digest }}'`. Keep this file sorted by Solana version (newest first).",
   "images": {
+    "3.1.14": "solanafoundation/solana-verifiable-build@sha256:f6b78c98ddb1774af9cf1b5ca00ccff4dac002eded106b4d44560c2c6be4188d",
     "2.3.5": "solanafoundation/solana-verifiable-build@sha256:c4d81ef3f4d540706988bca249ca8d827ab4c96c567f92c49d0d4a9a7a9337de",
     "1.18.26": "solanafoundation/solana-verifiable-build@sha256:ec2e20e1f80607150a71e4c72adfe64be24347ed0b4fb741c32b34eaf7549a25",
     "1.18.22": "solanafoundation/solana-verifiable-build@sha256:7804e1076ef24d4840f4fec24c88b5be8008e947cad2705516666a9f24b39de3",


### PR DESCRIPTION
Adds the `3.1.14` `solana-verifiable-build` image (platform-tools v1.52, rustc 1.89) to the lookup table.

Programs on the newer toolchain whose dependency tree requires `edition2024` (Cargo 1.85+) — e.g. mpl-core after its Solana 3 update (`block-buffer 0.12`, `base64ct 1.8`, …) — fail to verify-build against `2.3.5`, whose image ships Cargo 1.84. `3.1.14` is the newest official image and builds them.

Digest verified per this file's instructions:

```
docker buildx imagetools inspect solanafoundation/solana-verifiable-build:3.1.14 --format '{{ .Manifest.Digest }}'
# sha256:f6b78c98ddb1774af9cf1b5ca00ccff4dac002eded106b4d44560c2c6be4188d
```

Note for consumers pinned to `@v1`: this needs the `v1` tag moved to include the entry before `solana-version: 3.1.14` resolves there.
